### PR TITLE
Use stable tag for zypak

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -82,4 +82,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/refi64/zypak
-        tag: v2019.11beta.3
+        tag: v2020.02


### PR DESCRIPTION
There is only doc update between those but it looks better to use stable tag.