### PR TITLE
Remove GConf module

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -23,22 +23,6 @@ modules:
 
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
 
-  - name: gconf
-    cleanup:
-      - /bin
-      - /libexec
-      - /share
-      - /etc
-    config-opts:
-      - --disable-static
-      - --disable-gtk-doc
-      - --disable-orbit
-      - --disable-introspection
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/GConf/3.2/GConf-3.2.6.tar.xz
-        sha256: 1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c
-
   - name: libnotify
     buildsystem: meson
     config-opts:


### PR DESCRIPTION
GConf used to be a dependency of Chromium until around version 66 ([chromium#768027](https://bugs.chromium.org/p/chromium/issues/detail?id=768027)) and a dependency of Electron until version 7 (https://github.com/electron/electron/pull/19498). 

**I haven't actually checked this** but it's possible that GConf was never a direct dependency of Electron, but rather a transitive dependency coming from Chromium. If that's the case, then it would mean that Electron 2 was the latest version that actually required GConf (because Electron 3 was based on Chromium 66 ([source](https://github.com/electron/releases))).

So unless GConf is directly used by an app (which seems unlikely given that it's been deprecated for 8 years now), my impression is that not a lot of Electron apps *actually* need the GConf dependency. And the ones that do can still add it as a module to their manifest instead of inheriting it from `org.electronjs.Electron2.BaseApp`.