### PR TITLE
Remove cleanup bin on libnotify for notify-send

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -41,8 +41,6 @@ modules:
 
   - name: libnotify
     buildsystem: meson
-    cleanup:
-      - /bin
     config-opts:
       - -Dtests=false
       - -Dintrospection=disabled


### PR DESCRIPTION
`libnotify` only builds `notify-send`.   
I think it's ok to remove the cleanup.   

issue: https://github.com/flathub/org.electronjs.Electron2.BaseApp/issues/27