### PR TITLE
23.08 branch

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -1,8 +1,8 @@
 id: org.electronjs.Electron2.BaseApp
-branch: '22.08'
+branch: '23.08'
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 separate-locales: false
 cleanup:
   - /include

--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -44,12 +44,13 @@ modules:
     config-opts:
       - -Dtests=false
       - -Dintrospection=disabled
+      - -Dman=false
       - -Dgtk_doc=false
       - -Ddocbook_docs=disabled
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.8.tar.xz
-        sha256: 69209e0b663776a00c7b6c0e560302a8dbf66b2551d55616304f240bba66e18c
+        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz
+        sha256: c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616
 
   - name: gvfs-trash
     buildsystem: simple

--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -19,7 +19,7 @@ cleanup:
   - '*.la'
   - '*.a'
 modules:
-  - shared-modules/dbus-glib/dbus-glib-0.110.json
+  - shared-modules/dbus-glib/dbus-glib.json
 
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
 


### PR DESCRIPTION
Closes https://github.com/flathub/org.electronjs.Electron2.BaseApp/issues/43



Hopefully with the newer libnotify applications can drop poking notification holes.