### PR TITLE
Build Zypak from latest commit

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -81,8 +81,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/refi64/zypak
-        tag: v2022.04
-        commit: 55a60d110301e8dd37b631503c3524ab7baaf7aa
+        commit: ded79a2f8a509adc21834b95a9892073d4a91fdc
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
There have been [a handful of fixes](ded79a2f8a509adc21834b95a9892073d4a91fdc) in Zypak since the last tag, including [one](https://github.com/refi64/zypak/commit/c7daf0cc5b82eb5f63a1665cf7d72ff267100690) which I think we need to keep updating the Zoom flatpak (built on top of this baseapp).

I have [asked for](https://github.com/refi64/zypak/issues/41) a new tag of Zypak, but I don't know when that might happen.