### PR TITLE
Add libunity

### DIFF
--- a/libunity.yml
+++ b/libunity.yml
@@ -1,0 +1,92 @@
+name: libunity
+buildsystem: autotools
+build-options:
+    prepend-path: /usr/lib/sdk/vala/bin
+    prepend-ld-library-path: /usr/lib/sdk/vala/lib
+    env:
+        ACLOCAL_FLAGS: "-I /app/share/aclocal"
+sources:
+  - type: archive
+    url: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libunity/7.1.4+19.04.20190319-0ubuntu1/libunity_7.1.4+19.04.20190319.orig.tar.gz
+    sha256: 56ecb380d74bf74caba193d9e8ad6b0c85ccf9eeb461bc9731c2b8636e1f1492
+
+  - type: patch
+    path: patches/libunity/0001-Fix-FTB-with-recent-vala-requiring-non-public-abstra.patch
+
+  - type: patch
+    path: patches/libunity/libunity-7.1.4-vala-053.patch
+cleanup:
+  - /bin
+  - /share/unity
+  - /share/glib-2.0
+  - /share/unity-scopes
+modules:
+  - name: gnome-common
+    buildsystem: autotools
+    config-opts:
+      - --disable-schemas-compile
+      - --disable-silent-rules
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/gnome-common/3.7/gnome-common-3.7.4.tar.xz
+        sha256: 2af2d97010d2a9aeb3b99dd2ce07d1ef023e15a27b412ffe4f067f016ff7117b
+    cleanup:
+      - "*"
+
+  - name: automake
+    buildsystem: simple
+    build-commands:
+      - ln -s /usr/bin/automake ${FLATPAK_DEST}/bin/automake-1.13
+    cleanup:
+      - "*"
+
+  - shared-modules/intltool/intltool-0.51.json
+
+  - name: aclocal
+    buildsystem: simple
+    build-commands:
+      - ln -s /usr/bin/aclocal ${FLATPAK_DEST}/bin/aclocal-1.13
+    cleanup:
+      - "*"
+
+  - name: dee
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://launchpad.net/dee/1.0/1.2.7/+download/dee-1.2.7.tar.gz
+        sha256: 1bf0336ce684aa0f48d6eae2469628c1a9b43695a77443bc31a5790aa673bf8a
+
+      - type: patch
+        path: patches/dee/dee-1.2.7-deprecated-g_type_class_add_private.patch
+
+      - type: patch
+        path: patches/dee/dee-1.2.7-fix-g_string_free-usage.patch
+
+      - type: patch
+        path: patches/dee/dee-1.2.7-gcc6-fixes.patch
+    cleanup:
+      - /bin
+
+  - name: libdbusmenu-glib
+    buildsystem: autotools
+    build-options:
+        cflags: "-Wno-error"
+        env:
+            HAVE_VALGRIND_FALSE: "#"
+            HAVE_VALGRIND_TRUE: ""
+    config-opts:
+      - --disable-static
+      - --disable-gtk-doc
+      - --enable-introspection=yes
+      - --disable-vala
+      - --disable-dumper
+      - --disable-tests
+      - --with-gtk=3
+    sources:
+      - type: archive
+        url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
+        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
+      - type: patch
+        path: patches/libdbusmenu-glib/no-Werror.patch

--- a/libunity.yml
+++ b/libunity.yml
@@ -78,7 +78,7 @@ modules:
     config-opts:
       - --disable-static
       - --disable-gtk-doc
-      - --enable-introspection=no
+      - --enable-introspection=yes
       - --disable-vala
       - --disable-dumper
       - --disable-tests

--- a/libunity.yml
+++ b/libunity.yml
@@ -78,7 +78,7 @@ modules:
     config-opts:
       - --disable-static
       - --disable-gtk-doc
-      - --enable-introspection=yes
+      - --enable-introspection=no
       - --disable-vala
       - --disable-dumper
       - --disable-tests

--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -4,6 +4,8 @@ runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
 runtime-version: '23.08'
 separate-locales: false
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.vala
 cleanup:
   - /include
   - /lib/pkgconfig
@@ -35,6 +37,8 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz
         sha256: ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0
+
+  - libunity.yml
 
   - name: gvfs-trash
     buildsystem: simple

--- a/patches/dee/dee-1.2.7-deprecated-g_type_class_add_private.patch
+++ b/patches/dee/dee-1.2.7-deprecated-g_type_class_add_private.patch
@@ -1,0 +1,927 @@
+diff -up dee-1.2.7/configure.ac.dep dee-1.2.7/configure.ac
+--- dee-1.2.7/configure.ac.dep	2013-09-09 05:22:35.000000000 -0400
++++ dee-1.2.7/configure.ac	2019-09-05 11:17:15.833415732 -0400
+@@ -95,7 +95,7 @@ AC_FUNC_MMAP
+ AC_CHECK_FUNCS([memset munmap strcasecmp strdup])
+ 
+ PKG_CHECK_MODULES(DEE,
+-                  glib-2.0     >= 2.32
++                  glib-2.0     >= 2.38
+                   gthread-2.0  >= 2.32
+                   gobject-2.0  >= 2.32
+                   gio-2.0      >= 2.32
+diff -up dee-1.2.7/src/dee-analyzer.c.dep dee-1.2.7/src/dee-analyzer.c
+--- dee-1.2.7/src/dee-analyzer.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-analyzer.c	2019-09-05 11:22:55.498031535 -0400
+@@ -45,13 +45,6 @@
+ #include <string.h>
+ #include "dee-analyzer.h"
+ 
+-G_DEFINE_TYPE (DeeAnalyzer,
+-               dee_analyzer,
+-               G_TYPE_OBJECT);
+-
+-#define DEE_ANALYZER_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_ANALYZER, DeeAnalyzerPrivate))
+-
+ typedef struct {
+   DeeTermFilterFunc filter_func;
+   gpointer          data;
+@@ -76,6 +69,10 @@ enum
+   PROP_0,
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeAnalyzer,
++               dee_analyzer,
++               G_TYPE_OBJECT);
++
+ /*
+  * DeeAnalyzer forward declarations
+  */
+@@ -195,9 +192,6 @@ dee_analyzer_class_init (DeeAnalyzerClas
+   klass->add_term_filter = dee_analyzer_add_term_filter_real;
+   klass->collate_key = dee_analyzer_collate_key_real;
+   klass->collate_cmp = dee_analyzer_collate_cmp_real;
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeAnalyzerPrivate));
+ }
+ 
+ static void
+@@ -205,7 +199,7 @@ dee_analyzer_init (DeeAnalyzer *self)
+ {
+   DeeAnalyzerPrivate *priv;
+ 
+-  priv = self->priv = DEE_ANALYZER_GET_PRIVATE (self);
++  priv = self->priv = dee_analyzer_get_instance_private (self);
+   
+   priv->term_filters = NULL;
+   priv->term_pool = (DeeTermList*) g_object_new (DEE_TYPE_TERM_LIST, NULL);
+diff -up dee-1.2.7/src/dee-client.c.dep dee-1.2.7/src/dee-client.c
+--- dee-1.2.7/src/dee-client.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-client.c	2019-09-05 11:42:29.972418434 -0400
+@@ -37,11 +37,6 @@
+ #include "dee-marshal.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeeClient, dee_client, DEE_TYPE_PEER)
+-
+-#define GET_PRIVATE(o) \
+-      (G_TYPE_INSTANCE_GET_PRIVATE ((o), DEE_TYPE_CLIENT, DeeClientPrivate))
+-
+ /**
+  * DeeClientPrivate:
+  *
+@@ -69,6 +64,8 @@ enum
+   LAST_SIGNAL
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeClient, dee_client, DEE_TYPE_PEER)
++
+ //static guint32 _server_signals[LAST_SIGNAL] = { 0 };
+ 
+ /* Forwards */
+@@ -208,8 +205,6 @@ dee_client_class_init (DeeClientClass *k
+   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+   DeePeerClass *peer_class = DEE_PEER_CLASS (klass);
+ 
+-  g_type_class_add_private (klass, sizeof (DeeClientPrivate));
+-
+   object_class->constructed    = dee_client_constructed;
+   object_class->get_property   = dee_client_get_property;
+   object_class->set_property   = dee_client_set_property;
+@@ -238,7 +233,7 @@ dee_client_class_init (DeeClientClass *k
+ static void
+ dee_client_init (DeeClient *self)
+ {
+-  self->priv = GET_PRIVATE (self);
++  self->priv = dee_client_get_instance_private (self);
+ }
+ 
+ /**
+diff -up dee-1.2.7/src/dee-file-resource-manager.c.dep dee-1.2.7/src/dee-file-resource-manager.c
+--- dee-1.2.7/src/dee-file-resource-manager.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-file-resource-manager.c	2019-09-05 11:30:57.925525012 -0400
+@@ -41,14 +41,6 @@
+ #include "trace-log.h"
+ 
+ static void dee_file_resource_manager_resource_manager_iface_init (DeeResourceManagerIface *iface);
+-G_DEFINE_TYPE_WITH_CODE (DeeFileResourceManager,
+-                         dee_file_resource_manager,
+-                         G_TYPE_OBJECT,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_RESOURCE_MANAGER,
+-                                                dee_file_resource_manager_resource_manager_iface_init))
+-
+-#define DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_FILE_RESOURCE_MANAGER, DeeFileResourceManagerPrivate))
+ 
+ enum
+ {
+@@ -66,13 +58,20 @@ typedef struct
+   GHashTable *monitors_by_id;
+ } DeeFileResourceManagerPrivate;
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeFileResourceManager,
++                         dee_file_resource_manager,
++                         G_TYPE_OBJECT,
++                         G_ADD_PRIVATE(DeeFileResourceManager)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_RESOURCE_MANAGER,
++                                                dee_file_resource_manager_resource_manager_iface_init))
++
+ /* GObject Init */
+ static void
+ dee_file_resource_manager_finalize (GObject *object)
+ {
+   DeeFileResourceManagerPrivate *priv;
+   
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (object);
++  priv = dee_file_resource_manager_get_instance_private ((DeeFileResourceManager*) object);
+   
+   g_slist_free_full (priv->resource_dirs, g_free);
+   priv->resource_dirs = NULL;
+@@ -121,7 +120,7 @@ dee_file_resource_manager_get_property (
+ {
+   DeeFileResourceManagerPrivate *priv;
+ 
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (object);
++  priv = dee_file_resource_manager_get_instance_private ((DeeFileResourceManager *) object);
+ 
+   switch (id)
+     {
+@@ -156,9 +155,6 @@ dee_file_resource_manager_class_init (De
+                               G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                               | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_PRIMARY_PATH, pspec);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeFileResourceManagerPrivate));
+ }
+ 
+ static void
+@@ -166,7 +162,7 @@ dee_file_resource_manager_init (DeeFileR
+ {
+   DeeFileResourceManagerPrivate *priv;
+ 
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (self);
++  priv = dee_file_resource_manager_get_instance_private (self);
+   priv->resource_dirs = NULL;
+   priv->monitors_by_id = g_hash_table_new_full(g_direct_hash,
+                                                g_direct_equal,
+@@ -222,7 +218,7 @@ dee_file_resource_manager_add_search_pat
+   g_return_if_fail (DEE_IS_FILE_RESOURCE_MANAGER (self));
+   g_return_if_fail (path != NULL);
+ 
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (self);
++  priv = dee_file_resource_manager_get_instance_private ((DeeFileResourceManager *) self);
+   priv->resource_dirs = g_slist_append (priv->resource_dirs,
+                                         g_strdup (path));
+ }
+@@ -242,7 +238,7 @@ dee_file_resource_manager_get_primary_pa
+ 
+   g_return_val_if_fail (DEE_IS_FILE_RESOURCE_MANAGER (self), NULL);
+ 
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (self);
++  priv = dee_file_resource_manager_get_instance_private ((DeeFileResourceManager *) self);
+   return (const gchar *) priv->resource_dirs->data;
+ }
+ 
+@@ -393,7 +389,7 @@ dee_file_resource_manager_load (DeeResou
+   g_return_val_if_fail (resource_name != NULL, NULL);
+   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+ 
+-  priv = DEE_FILE_RESOURCE_MANAGER_GET_PRIVATE (self);
++  priv = dee_file_resource_manager_get_instance_private ((DeeFileResourceManager *) self);
+ 
+   for (iter = priv->resource_dirs; iter != NULL; iter = iter->next)
+     {
+diff -up dee-1.2.7/src/dee-filter-model.c.dep dee-1.2.7/src/dee-filter-model.c
+--- dee-1.2.7/src/dee-filter-model.c.dep	2013-09-10 06:57:15.000000000 -0400
++++ dee-1.2.7/src/dee-filter-model.c	2019-09-05 11:32:21.687699629 -0400
+@@ -65,15 +65,6 @@
+ 
+ static void dee_filter_model_model_iface_init (DeeModelIface *iface);
+ 
+-G_DEFINE_TYPE_WITH_CODE (DeeFilterModel,
+-                         dee_filter_model,
+-                         DEE_TYPE_PROXY_MODEL,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+-                                                dee_filter_model_model_iface_init));
+-
+-#define DEE_FILTER_MODEL_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_FILTER_MODEL, DeeFilterModelPrivate))
+-
+ /**
+  * DeeFilterModelPrivate:
+  *
+@@ -107,6 +98,13 @@ enum
+   PROP_FILTER,
+ };
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeFilterModel,
++                         dee_filter_model,
++                         DEE_TYPE_PROXY_MODEL,
++                         G_ADD_PRIVATE(DeeFilterModel)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
++                                                dee_filter_model_model_iface_init));
++
+ /*
+  * DeeModel forward declarations
+  */
+@@ -332,9 +330,6 @@ dee_filter_model_class_init (DeeFilterMo
+                                 G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                                 | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_FILTER, pspec);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeFilterModelPrivate));
+ }
+ 
+ static void
+@@ -342,7 +337,7 @@ dee_filter_model_init (DeeFilterModel *s
+ {
+   DeeFilterModelPrivate *priv;
+ 
+-  priv = self->priv = DEE_FILTER_MODEL_GET_PRIVATE (self);
++  priv = self->priv = dee_filter_model_get_instance_private (self);
+   
+   priv->iter_map = g_hash_table_new (g_direct_hash, g_direct_equal);
+   priv->iter_list = g_sequence_new (NULL);
+diff -up dee-1.2.7/src/dee-glist-result-set.c.dep dee-1.2.7/src/dee-glist-result-set.c
+--- dee-1.2.7/src/dee-glist-result-set.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-glist-result-set.c	2019-09-05 11:37:49.387557145 -0400
+@@ -32,14 +32,6 @@
+ #include "dee-glist-result-set.h"
+ 
+ static void dee_glist_result_set_result_set_iface_init (DeeResultSetIface *iface);
+-G_DEFINE_TYPE_WITH_CODE (DeeGListResultSet,
+-                         dee_glist_result_set,
+-                         G_TYPE_OBJECT,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_RESULT_SET,
+-                                                dee_glist_result_set_result_set_iface_init))
+-
+-#define DEE_GLIST_RESULT_SET_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_GLIST_RESULT_SET, DeeGListResultSetPrivate))
+ 
+ typedef struct
+ {
+@@ -52,13 +44,20 @@ typedef struct
+   gboolean  n_rows_calculated;
+ } DeeGListResultSetPrivate;
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeGListResultSet,
++                         dee_glist_result_set,
++                         G_TYPE_OBJECT,
++                         G_ADD_PRIVATE(DeeGListResultSet)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_RESULT_SET,
++                                                dee_glist_result_set_result_set_iface_init))
++
+ /* GObject Init */
+ static void
+ dee_glist_result_set_finalize (GObject *object)
+ {
+   DeeGListResultSetPrivate *priv;
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (object);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) object);
+   
+   if (priv->model)
+     g_object_unref (priv->model);
+@@ -74,9 +73,6 @@ dee_glist_result_set_class_init (DeeGLis
+   GObjectClass  *obj_class = G_OBJECT_CLASS (klass);
+ 
+   obj_class->finalize     = dee_glist_result_set_finalize;
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeGListResultSetPrivate));
+ }
+ 
+ static void
+@@ -84,7 +80,7 @@ dee_glist_result_set_init (DeeGListResul
+ {
+   DeeGListResultSetPrivate *priv;
+ 
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private (self);
+   priv->pos = 0;
+   priv->n_rows_calculated = FALSE;
+ }
+@@ -96,7 +92,7 @@ dee_glist_result_set_get_n_rows (DeeResu
+   
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), 0);
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   
+   if (!priv->n_rows_calculated)
+     {
+@@ -116,7 +112,7 @@ dee_glist_result_set_next (DeeResultSet
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), NULL);
+   g_return_val_if_fail (dee_result_set_has_next (self), NULL);
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   next = dee_result_set_peek (self);
+   priv->cursor = priv->cursor->next;
+   priv->pos++;
+@@ -130,7 +126,7 @@ dee_glist_result_set_has_next (DeeResult
+   
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), FALSE);
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+ 
+   return priv->cursor != NULL;
+ }
+@@ -142,7 +138,7 @@ dee_glist_result_set_peek (DeeResultSet
+   
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), NULL);
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+ 
+   if (priv->cursor == NULL)
+     return NULL;
+@@ -158,7 +154,7 @@ dee_glist_result_set_seek (DeeResultSet
+   
+   g_return_if_fail (DEE_IS_GLIST_RESULT_SET (self));
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   priv->cursor = g_list_nth (priv->rows, pos);
+   priv->pos = pos;
+ 
+@@ -177,7 +173,7 @@ dee_glist_result_set_tell (DeeResultSet
+   
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), 0);
+   
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   return priv->pos;
+ }
+ 
+@@ -188,7 +184,7 @@ dee_glist_result_set_get_model (DeeResul
+ 
+   g_return_val_if_fail (DEE_IS_GLIST_RESULT_SET (self), NULL);
+ 
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   return priv->model;
+ }
+ 
+@@ -216,7 +212,7 @@ dee_glist_result_set_new (GList    *rows
+   DeeGListResultSetPrivate *priv;
+ 
+   self = g_object_new (DEE_TYPE_GLIST_RESULT_SET, NULL);
+-  priv = DEE_GLIST_RESULT_SET_GET_PRIVATE (self);
++  priv = dee_glist_result_set_get_instance_private ((DeeGListResultSet *) self);
+   priv->rows = rows;
+   priv->cursor = rows;
+   priv->model = g_object_ref (model);
+diff -up dee-1.2.7/src/dee-hash-index.c.dep dee-1.2.7/src/dee-hash-index.c
+--- dee-1.2.7/src/dee-hash-index.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-hash-index.c	2019-09-05 11:38:58.981034578 -0400
+@@ -37,11 +37,6 @@
+ #include "dee-glist-result-set.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeeHashIndex, dee_hash_index, DEE_TYPE_INDEX);
+-
+-#define DEE_HASH_INDEX_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_HASH_INDEX, DeeHashIndexPrivate))
+-
+ /*
+  * FORWARDS
+  */
+@@ -102,6 +97,8 @@ enum
+   PROP_0,
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeHashIndex, dee_hash_index, DEE_TYPE_INDEX);
++
+ /* GObject stuff */
+ static void
+ dee_hash_index_finalize (GObject *object)
+@@ -180,15 +177,12 @@ dee_hash_index_class_init (DeeHashIndexC
+   idx_class->get_n_rows  = dee_hash_index_get_n_rows;
+   idx_class->get_n_rows_for_term = dee_hash_index_get_n_rows_for_term;
+   idx_class->get_supported_term_match_flags  = dee_hash_index_get_supported_term_match_flags;
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeHashIndexPrivate));
+ }
+ 
+ static void
+ dee_hash_index_init (DeeHashIndex *self)
+ {
+-  self->priv = DEE_HASH_INDEX_GET_PRIVATE (self);
++  self->priv = dee_hash_index_get_instance_private (self);
+ 
+   self->priv->terms = g_hash_table_new (g_str_hash, g_str_equal);
+   self->priv->row_terms = g_hash_table_new_full(g_direct_hash, g_direct_equal,
+diff -up dee-1.2.7/src/dee-index.c.dep dee-1.2.7/src/dee-index.c
+--- dee-1.2.7/src/dee-index.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-index.c	2019-09-05 11:39:52.657860216 -0400
+@@ -43,11 +43,6 @@
+ #include "dee-marshal.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_ABSTRACT_TYPE (DeeIndex, dee_index, G_TYPE_OBJECT);
+-
+-#define DEE_INDEX_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_INDEX, DeeIndexPrivate))
+-
+ /**
+  * DeeIndexPrivate:
+  *
+@@ -68,6 +63,8 @@ enum
+   PROP_READER
+ };
+ 
++G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (DeeIndex, dee_index, G_TYPE_OBJECT);
++
+ /* GObject stuff */
+ static void
+ dee_index_finalize (GObject *object)
+@@ -195,15 +192,12 @@ dee_index_class_init (DeeIndexClass *kla
+                                  G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY
+                                  | G_PARAM_STATIC_STRINGS);
+     g_object_class_install_property (obj_class, PROP_READER, pspec);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeIndexPrivate));
+ }
+ 
+ static void
+ dee_index_init (DeeIndex *self)
+ {
+-  self->priv = DEE_INDEX_GET_PRIVATE (self);
++  self->priv = dee_index_get_instance_private (self);
+ }
+ 
+ /**
+diff -up dee-1.2.7/src/dee-peer.c.dep dee-1.2.7/src/dee-peer.c
+--- dee-1.2.7/src/dee-peer.c.dep	2013-07-21 18:27:22.000000000 -0400
++++ dee-1.2.7/src/dee-peer.c	2019-09-05 11:40:51.330576540 -0400
+@@ -62,11 +62,6 @@
+ #include "dee-marshal.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeePeer, dee_peer, G_TYPE_OBJECT)
+-
+-#define DEE_PEER_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_PEER, DeePeerPrivate))
+-
+ #define _DeePeerIter GSequenceIter
+ 
+ /**
+@@ -145,6 +140,8 @@ enum
+   LAST_SIGNAL
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeePeer, dee_peer, G_TYPE_OBJECT)
++
+ static guint32 _peer_signals[LAST_SIGNAL] = { 0 };
+ 
+ /* Forwards */
+@@ -568,9 +565,6 @@ dee_peer_class_init (DeePeerClass *klass
+                                 G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                                 | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_SWARM_OWNER, pspec);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeePeerPrivate));
+ }
+ 
+ static void
+@@ -578,7 +572,7 @@ dee_peer_init (DeePeer *peer)
+ {
+   DeePeerPrivate *priv;
+ 
+-  priv = peer->priv = DEE_PEER_GET_PRIVATE (peer);
++  priv = peer->priv = dee_peer_get_instance_private (peer);
+ 
+   priv->swarm_name = NULL;
+   priv->swarm_leader = NULL;
+diff -up dee-1.2.7/src/dee-proxy-model.c.dep dee-1.2.7/src/dee-proxy-model.c
+--- dee-1.2.7/src/dee-proxy-model.c.dep	2013-09-10 06:52:03.000000000 -0400
++++ dee-1.2.7/src/dee-proxy-model.c	2019-09-05 11:43:32.123058716 -0400
+@@ -43,15 +43,6 @@
+ 
+ static void dee_proxy_model_model_iface_init (DeeModelIface *iface);
+ 
+-G_DEFINE_TYPE_WITH_CODE (DeeProxyModel,
+-                         dee_proxy_model,
+-                         DEE_TYPE_SERIALIZABLE_MODEL,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+-                                                dee_proxy_model_model_iface_init));
+-
+-#define DEE_PROXY_MODEL_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_PROXY_MODEL, DeeProxyModelPrivate))
+-
+ enum
+ {
+   PROP_0,
+@@ -85,6 +76,13 @@ struct _DeeProxyModelPrivate
+   gulong     changeset_finished_handler;
+ };
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeProxyModel,
++                         dee_proxy_model,
++                         DEE_TYPE_SERIALIZABLE_MODEL,
++                         G_ADD_PRIVATE(DeeProxyModel)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
++                                                dee_proxy_model_model_iface_init));
++
+ #define DEE_PROXY_MODEL_BACK_END(model) (DEE_PROXY_MODEL(model)->priv->back_end)
+ #define SUPER_CLASS DEE_SERIALIZABLE_MODEL_CLASS (dee_proxy_model_parent_class)
+ 
+@@ -441,9 +439,6 @@ dee_proxy_model_class_init (DeeProxyMode
+                                 G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                                 | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_INHERIT_SEQNUMS, pspec);
+-  
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeProxyModelPrivate));
+ }
+ 
+ static void
+@@ -500,7 +495,7 @@ dee_proxy_model_init (DeeProxyModel *mod
+ {
+   DeeProxyModelPrivate *priv;
+ 
+-  priv = model->priv = DEE_PROXY_MODEL_GET_PRIVATE (model);
++  priv = model->priv = dee_proxy_model_get_instance_private (model);
+   priv->back_end = NULL;
+   priv->inherit_seqnums = TRUE;
+   
+diff -up dee-1.2.7/src/dee-sequence-model.c.dep dee-1.2.7/src/dee-sequence-model.c
+--- dee-1.2.7/src/dee-sequence-model.c.dep	2013-09-16 14:07:09.000000000 -0400
++++ dee-1.2.7/src/dee-sequence-model.c	2019-09-05 11:45:05.301020171 -0400
+@@ -49,15 +49,6 @@
+ 
+ static void dee_sequence_model_model_iface_init (DeeModelIface *iface);
+ 
+-G_DEFINE_TYPE_WITH_CODE (DeeSequenceModel,
+-                         dee_sequence_model,
+-                         DEE_TYPE_SERIALIZABLE_MODEL,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+-                                                dee_sequence_model_model_iface_init));
+-
+-#define DEE_SEQUENCE_MODEL_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_SEQUENCE_MODEL, DeeSequenceModelPrivate))
+-
+ /* Signal ids for emitting row update signals a just a smidgeon faster */
+ static guint sigid_row_added;
+ static guint sigid_row_removed;
+@@ -85,6 +76,13 @@ struct _DeeSequenceModelPrivate
+   gboolean   setting_many;
+ };
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeSequenceModel,
++                         dee_sequence_model,
++                         DEE_TYPE_SERIALIZABLE_MODEL,
++                         G_ADD_PRIVATE(DeeSequenceModel)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
++                                                dee_sequence_model_model_iface_init));
++
+ /*
+  * DeeModel forward declarations
+  */
+@@ -283,9 +281,6 @@ dee_sequence_model_class_init (DeeSequen
+   sigid_row_added = g_signal_lookup ("row-added", DEE_TYPE_MODEL);
+   sigid_row_removed = g_signal_lookup ("row-removed", DEE_TYPE_MODEL);
+   sigid_row_changed = g_signal_lookup ("row-changed", DEE_TYPE_MODEL);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeSequenceModelPrivate));
+ }
+ 
+ static void
+@@ -327,7 +322,7 @@ dee_sequence_model_init (DeeSequenceMode
+ {
+   DeeSequenceModelPrivate *priv;
+ 
+-  priv = model->priv = DEE_SEQUENCE_MODEL_GET_PRIVATE (model);
++  priv = model->priv = dee_sequence_model_get_instance_private (model);
+   priv->sequence = g_sequence_new (NULL);
+   priv->tags = NULL;
+   priv->setting_many = FALSE;
+diff -up dee-1.2.7/src/dee-serializable-model.c.dep dee-1.2.7/src/dee-serializable-model.c
+--- dee-1.2.7/src/dee-serializable-model.c.dep	2019-09-05 11:17:15.831415776 -0400
++++ dee-1.2.7/src/dee-serializable-model.c	2019-09-05 11:46:05.331706803 -0400
+@@ -47,16 +47,6 @@
+ static void     dee_serializable_model_model_iface_init (DeeModelIface *iface);
+ static void     dee_serializable_model_serializable_iface_init (DeeSerializableIface *iface);
+ static GObject* dee_serializable_model_parse_serialized (GVariant *data);
+-G_DEFINE_ABSTRACT_TYPE_WITH_CODE (DeeSerializableModel,
+-                                  dee_serializable_model,
+-                                  G_TYPE_OBJECT,
+-                                  G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+-                                                         dee_serializable_model_model_iface_init)
+-                                  G_IMPLEMENT_INTERFACE (DEE_TYPE_SERIALIZABLE,
+-                                                         dee_serializable_model_serializable_iface_init));
+-
+-#define DEE_SERIALIZABLE_MODEL_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_SERIALIZABLE_MODEL, DeeSerializableModelPrivate))
+ 
+ #define MODEL_VARIANT_TYPE_1_0 G_VARIANT_TYPE ("(asaav(tt))")
+ #define MODEL_VARIANT_TYPE     G_VARIANT_TYPE ("(asaav(tt)a{sv})")
+@@ -80,6 +70,15 @@ struct _DeeSerializableModelPrivate
+   gboolean    inside_changeset;
+ };
+ 
++G_DEFINE_ABSTRACT_TYPE_WITH_CODE (DeeSerializableModel,
++                                  dee_serializable_model,
++                                  G_TYPE_OBJECT,
++                                  G_ADD_PRIVATE(DeeSerializableModel)
++                                  G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
++                                                         dee_serializable_model_model_iface_init)
++                                  G_IMPLEMENT_INTERFACE (DEE_TYPE_SERIALIZABLE,
++                                                         dee_serializable_model_serializable_iface_init));
++
+ typedef struct _FieldSchemaInfo FieldSchemaInfo;
+ 
+ struct _FieldSchemaInfo
+@@ -362,9 +361,6 @@ dee_serializable_model_class_init (DeeSe
+ 
+   sigid_changeset_started = g_signal_lookup ("changeset-started", DEE_TYPE_MODEL);
+   sigid_changeset_finished = g_signal_lookup ("changeset-finished", DEE_TYPE_MODEL);
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeSerializableModelPrivate));
+ }
+ 
+ static void
+@@ -372,7 +368,7 @@ dee_serializable_model_init (DeeSerializ
+ {
+   DeeSerializableModelPrivate *priv;
+ 
+-  priv = model->priv = DEE_SERIALIZABLE_MODEL_GET_PRIVATE (model);
++  priv = model->priv = dee_serializable_model_get_instance_private (model);
+ 
+   priv->seqnum = 0;
+ 
+diff -up dee-1.2.7/src/dee-server.c.dep dee-1.2.7/src/dee-server.c
+--- dee-1.2.7/src/dee-server.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-server.c	2019-09-05 11:41:45.727386434 -0400
+@@ -39,11 +39,6 @@
+ #include "dee-marshal.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeeServer, dee_server, DEE_TYPE_PEER)
+-
+-#define GET_PRIVATE(o) \
+-      (G_TYPE_INSTANCE_GET_PRIVATE ((o), DEE_TYPE_SERVER, DeeServerPrivate))
+-
+ #define ACTIVE_CONNECTIONS_KEY "dee-active-connections-list"
+ #define CONNECTION_ACCEPTED_KEY "dee-connection-accepted"
+ 
+@@ -78,6 +73,8 @@ enum
+   LAST_SIGNAL
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeServer, dee_server, DEE_TYPE_PEER)
++
+ //static guint32 _server_signals[LAST_SIGNAL] = { 0 };
+ static GHashTable *active_servers = NULL;
+ 
+@@ -397,8 +394,6 @@ dee_server_class_init (DeeServerClass *k
+   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+   DeePeerClass *peer_class = DEE_PEER_CLASS (klass);
+ 
+-  g_type_class_add_private (klass, sizeof (DeeServerPrivate));
+-
+   object_class->constructed = dee_server_constructed;
+   object_class->get_property = dee_server_get_property;
+   object_class->set_property = dee_server_set_property;
+@@ -447,7 +442,7 @@ dee_server_class_init (DeeServerClass *k
+ static void
+ dee_server_init (DeeServer *self)
+ {
+-  self->priv = GET_PRIVATE (self);
++  self->priv = dee_server_get_instance_private (self);
+ 
+   self->priv->connection_id_map = g_hash_table_new_full (g_direct_hash,
+                                                          g_direct_equal,
+diff -up dee-1.2.7/src/dee-shared-model.c.dep dee-1.2.7/src/dee-shared-model.c
+--- dee-1.2.7/src/dee-shared-model.c.dep	2019-09-05 11:17:15.831415776 -0400
++++ dee-1.2.7/src/dee-shared-model.c	2019-09-05 11:46:58.495543664 -0400
+@@ -61,17 +61,6 @@ static void dee_shared_model_serializabl
+ 
+ static void dee_shared_model_model_iface_init        (DeeModelIface *iface);
+ 
+-G_DEFINE_TYPE_WITH_CODE (DeeSharedModel,
+-                         dee_shared_model,
+-                         DEE_TYPE_PROXY_MODEL,
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_SERIALIZABLE,
+-                                                dee_shared_model_serializable_iface_init)
+-                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+-                                                dee_shared_model_model_iface_init));
+-
+-#define DEE_SHARED_MODEL_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_SHARED_MODEL, DeeSharedModelPrivate))
+-
+ #define COMMIT_VARIANT_TYPE   G_VARIANT_TYPE("(sasaavauay(tt))")
+ #define COMMIT_TUPLE_ITEMS    6
+ #define CLONE_VARIANT_TYPE    G_VARIANT_TYPE("(sasaavauay(tt)a{sv})")
+@@ -109,6 +98,15 @@ struct _DeeSharedModelPrivate
+   DeeSharedModelFlushMode flush_mode;
+ };
+ 
++G_DEFINE_TYPE_WITH_CODE (DeeSharedModel,
++                         dee_shared_model,
++                         DEE_TYPE_PROXY_MODEL,
++                         G_ADD_PRIVATE(DeeSharedModel)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_SERIALIZABLE,
++                                                dee_shared_model_serializable_iface_init)
++                         G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
++                                                dee_shared_model_model_iface_init));
++
+ typedef struct
+ {
+   /* The revision type is: ROWS_ADDED, ROWS_REMOVED, or ROWS_CHANGED */
+@@ -806,9 +804,6 @@ dee_shared_model_class_init (DeeSharedMo
+                   G_TYPE_NONE, 2,
+                   G_TYPE_UINT64, G_TYPE_UINT64);
+ 
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeSharedModelPrivate));
+-
+   /* Runtime-check that our defines are correct */
+   g_assert (g_variant_type_n_items (CLONE_VARIANT_TYPE) == CLONE_TUPLE_ITEMS);
+   g_assert (g_variant_type_n_items (COMMIT_VARIANT_TYPE) == COMMIT_TUPLE_ITEMS);
+@@ -819,7 +814,7 @@ dee_shared_model_init (DeeSharedModel *s
+ {
+   DeeSharedModelPrivate *priv;
+ 
+-  priv = self->priv = DEE_SHARED_MODEL_GET_PRIVATE (self);
++  priv = self->priv = dee_shared_model_get_instance_private (self);
+ 
+   priv->swarm = NULL;
+   priv->model_path = NULL;
+diff -up dee-1.2.7/src/dee-term-list.c.dep dee-1.2.7/src/dee-term-list.c
+--- dee-1.2.7/src/dee-term-list.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-term-list.c	2019-09-05 11:47:44.472537770 -0400
+@@ -43,11 +43,6 @@
+ #include "dee-term-list.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeeTermList, dee_term_list, G_TYPE_OBJECT);
+-
+-#define DEE_TERM_LIST_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_TERM_LIST, DeeTermListPrivate))
+-
+ /*
+  * FORWARDS
+  */
+@@ -93,6 +88,8 @@ enum
+   PROP_0,
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeTermList, dee_term_list, G_TYPE_OBJECT);
++
+ #define CHECK_LAZY_SETUP(term_list) \
+   if (G_UNLIKELY(term_list->priv->chunk == NULL)) \
+     { \
+@@ -154,9 +151,6 @@ dee_term_list_class_init (DeeTermListCla
+                                 | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_FILTER, pspec);
+   */
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeTermListPrivate));
+ }
+ 
+ static void
+@@ -164,7 +158,7 @@ dee_term_list_init (DeeTermList *self)
+ {
+   DeeTermListPrivate *priv;
+ 
+-  priv = self->priv = DEE_TERM_LIST_GET_PRIVATE (self);
++  priv = self->priv = dee_term_list_get_instance_private (self);
+ 
+   /* The chunk and terms are allocated lazily, to make clone() work more
+    * eficiently */
+diff -up dee-1.2.7/src/dee-text-analyzer.c.dep dee-1.2.7/src/dee-text-analyzer.c
+--- dee-1.2.7/src/dee-text-analyzer.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-text-analyzer.c	2019-09-05 11:48:34.262448464 -0400
+@@ -36,14 +36,6 @@
+ 
+ #include "dee-text-analyzer.h"
+ 
+-G_DEFINE_TYPE (DeeTextAnalyzer,
+-               dee_text_analyzer,
+-               DEE_TYPE_ANALYZER);
+-
+-#define DEE_TEXT_ANALYZER_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_TEXT_ANALYZER, DeeTextAnalyzerPrivate))
+-
+-
+ /**
+  * DeeAnalyzerPrivate:
+  *
+@@ -59,6 +51,10 @@ enum
+   PROP_0,
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeTextAnalyzer,
++               dee_text_analyzer,
++               DEE_TYPE_ANALYZER);
++
+ /*
+  * DeeAnalyzer forward declarations
+  */
+@@ -88,15 +84,12 @@ dee_text_analyzer_class_init (DeeTextAna
+ 
+   a_class->tokenize = dee_text_analyzer_tokenize_real;
+   a_class->collate_key = dee_text_analyzer_collate_key_real;
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeTextAnalyzerPrivate));
+ }
+ 
+ static void
+ dee_text_analyzer_init (DeeTextAnalyzer *self)
+ {
+-  self->priv = DEE_TEXT_ANALYZER_GET_PRIVATE (self);
++  self->priv = dee_text_analyzer_get_instance_private (self);
+ }
+ 
+ /*
+diff -up dee-1.2.7/src/dee-transaction.c.dep dee-1.2.7/src/dee-transaction.c
+--- dee-1.2.7/src/dee-transaction.c.dep	2012-11-28 03:46:41.000000000 -0500
++++ dee-1.2.7/src/dee-transaction.c	2019-09-05 11:49:21.474415553 -0400
+@@ -403,12 +403,10 @@ static void dee_transaction_model_iface_
+ G_DEFINE_TYPE_WITH_CODE (DeeTransaction,
+                          dee_transaction,
+                          DEE_TYPE_SERIALIZABLE_MODEL,
++                         G_ADD_PRIVATE(DeeTransaction)
+                          G_IMPLEMENT_INTERFACE (DEE_TYPE_MODEL,
+                                                 dee_transaction_model_iface_init));
+ 
+-#define DEE_TRANSACTION_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_TRANSACTION, DeeTransactionPrivate))
+-
+ enum
+ {
+   PROP_0,
+@@ -644,9 +642,6 @@ dee_transaction_class_init (DeeTransacti
+                                G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY
+                                | G_PARAM_STATIC_STRINGS);
+   g_object_class_install_property (obj_class, PROP_TARGET, pspec);
+-  
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeTransactionPrivate));
+ }
+ 
+ static void
+@@ -695,7 +690,7 @@ dee_transaction_init (DeeTransaction *mo
+ {
+   DeeTransactionPrivate *priv;
+ 
+-  priv = model->priv = DEE_TRANSACTION_GET_PRIVATE (model);
++  priv = model->priv = dee_transaction_get_instance_private (model);
+   priv->target = NULL;
+   
+   priv->journal = g_hash_table_new (g_direct_hash, g_direct_equal);
+diff -up dee-1.2.7/src/dee-tree-index.c.dep dee-1.2.7/src/dee-tree-index.c
+--- dee-1.2.7/src/dee-tree-index.c.dep	2012-11-08 05:13:46.000000000 -0500
++++ dee-1.2.7/src/dee-tree-index.c	2019-09-05 11:50:32.860853766 -0400
+@@ -40,11 +40,6 @@
+ #include "dee-glist-result-set.h"
+ #include "trace-log.h"
+ 
+-G_DEFINE_TYPE (DeeTreeIndex, dee_tree_index, DEE_TYPE_INDEX);
+-
+-#define DEE_TREE_INDEX_GET_PRIVATE(obj) \
+-  (G_TYPE_INSTANCE_GET_PRIVATE(obj, DEE_TYPE_TREE_INDEX, DeeTreeIndexPrivate))
+-
+ /*
+  * FORWARDS
+  */
+@@ -310,6 +305,8 @@ enum
+   PROP_0,
+ };
+ 
++G_DEFINE_TYPE_WITH_PRIVATE (DeeTreeIndex, dee_tree_index, DEE_TYPE_INDEX);
++
+ /* GObject stuff */
+ static void
+ dee_tree_index_finalize (GObject *object)
+@@ -388,15 +385,12 @@ dee_tree_index_class_init (DeeTreeIndexC
+   idx_class->get_n_rows  = dee_tree_index_get_n_rows;
+   idx_class->get_n_rows_for_term = dee_tree_index_get_n_rows_for_term;
+   idx_class->get_supported_term_match_flags  = dee_tree_index_get_supported_term_match_flags;
+-
+-  /* Add private data */
+-  g_type_class_add_private (obj_class, sizeof (DeeTreeIndexPrivate));
+ }
+ 
+ static void
+ dee_tree_index_init (DeeTreeIndex *self)
+ {
+-  self->priv = DEE_TREE_INDEX_GET_PRIVATE (self);
++  self->priv = dee_tree_index_get_instance_private (self);
+ 
+   self->priv->terms = g_sequence_new ((GDestroyNotify) term_destroy);
+   self->priv->row_terms = g_hash_table_new_full(g_direct_hash, g_direct_equal,

--- a/patches/dee/dee-1.2.7-fix-g_string_free-usage.patch
+++ b/patches/dee/dee-1.2.7-fix-g_string_free-usage.patch
@@ -1,0 +1,33 @@
+diff -up dee-1.2.7/src/dee-icu-term-filter.c.freefix dee-1.2.7/src/dee-icu-term-filter.c
+--- dee-1.2.7/src/dee-icu-term-filter.c.freefix	2023-04-28 09:26:18.883264141 -0400
++++ dee-1.2.7/src/dee-icu-term-filter.c	2023-04-28 09:27:03.585836521 -0400
+@@ -100,8 +100,7 @@ print_error (const gchar *system_id,
+   if (u_parse_error->offset >= 0)
+     g_string_append_printf(str, " Offset %i.", u_parse_error->offset);
+ 
+-  msg = str->str;
+-  g_string_free (str, FALSE);
++  msg = g_string_free (str, FALSE);
+ 
+   return msg;
+ }
+diff -up dee-1.2.7/src/trace-log.c.freefix dee-1.2.7/src/trace-log.c
+--- dee-1.2.7/src/trace-log.c.freefix	2023-04-28 09:27:22.722081551 -0400
++++ dee-1.2.7/src/trace-log.c	2023-04-28 09:29:44.269893973 -0400
+@@ -27,6 +27,7 @@ trace_object_va (void        *obj,
+                  va_list      args)
+ {
+   GString   *tmp;
++  gchar   *msg;
+ 
+   if (!G_IS_OBJECT(obj)) {
+     g_critical ("Failed to log '%s' for object. Not an object.", format);
+@@ -38,7 +39,7 @@ trace_object_va (void        *obj,
+   g_string_append (tmp, format);
+   g_logv (TRACE_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, tmp->str, args);
+ 
+-  g_string_free (tmp, TRUE);
++  msg = g_string_free (tmp, TRUE);
+ }
+ 
+ void

--- a/patches/dee/dee-1.2.7-gcc6-fixes.patch
+++ b/patches/dee/dee-1.2.7-gcc6-fixes.patch
@@ -1,0 +1,36 @@
+diff -up dee-1.2.7/src/dee-serializable-model.c.fix dee-1.2.7/src/dee-serializable-model.c
+--- dee-1.2.7/src/dee-serializable-model.c.fix	2016-02-12 11:23:15.745512142 -0500
++++ dee-1.2.7/src/dee-serializable-model.c	2016-02-12 11:24:31.251827989 -0500
+@@ -1326,9 +1326,10 @@ dee_serializable_model_get_position (Dee
+ 
+   pos = 0;
+   _iter = dee_model_get_first_iter (self);
+-  while (!dee_model_is_last (self, iter) && iter != _iter)
++  while (!dee_model_is_last (self, iter) && iter != _iter) {
+     _iter = dee_model_next (self, _iter);
+     pos++;
++  }
+ 
+   if (iter == _iter)
+     return pos;
+diff -up dee-1.2.7/src/dee-shared-model.c.fix dee-1.2.7/src/dee-shared-model.c
+--- dee-1.2.7/src/dee-shared-model.c.fix	2016-02-12 11:27:13.807355094 -0500
++++ dee-1.2.7/src/dee-shared-model.c	2016-02-12 11:28:28.530678035 -0500
+@@ -1083,7 +1083,7 @@ on_clone_received (GObject      *source_
+   if (data != NULL)
+     {
+       const gchar **column_names;
+-      guint         i, n_column_names;
++      guint         i, n_column_names = 0;
+       GVariant     *vardict;
+       GVariantIter *iter;
+ 
+@@ -2242,7 +2242,7 @@ dee_shared_model_parse_serialized (GVari
+   GVariantIter   *vardict_schema_iter;
+   const gchar   **column_names;
+   gchar          *swarm_name;
+-  guint           i, n_cols;
++  guint           i, n_cols = 0;
+   gsize           tuple_items;
+ 
+   g_return_val_if_fail (data != NULL, NULL);

--- a/patches/libdbusmenu-glib/no-Werror.patch
+++ b/patches/libdbusmenu-glib/no-Werror.patch
@@ -1,0 +1,53 @@
+diff --git a/libdbusmenu-glib/Makefile.am b/libdbusmenu-glib/Makefile.am
+index 2dea5f6..01832ce 100644
+--- a/libdbusmenu-glib/Makefile.am
++++ b/libdbusmenu-glib/Makefile.am
+@@ -66,7 +66,7 @@ libdbusmenu_glib_la_LDFLAGS = \
+ libdbusmenu_glib_la_CFLAGS = \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GLIB\""
+
+ libdbusmenu_glib_la_LIBADD = \
+diff --git a/libdbusmenu-gtk/Makefile.am b/libdbusmenu-gtk/Makefile.am
+index 9a7a2b0..a9a2b49 100644
+--- a/libdbusmenu-gtk/Makefile.am
++++ b/libdbusmenu-gtk/Makefile.am
+@@ -66,7 +66,7 @@ libdbusmenu_gtk_la_CFLAGS = \
+ 	$(DBUSMENUGTK_CFLAGS) \
+ 	$(COVERAGE_CFLAGS) \
+ 	-I$(top_srcdir) \
+-	-Wall -Werror -Wno-error=deprecated-declarations \
++	-Wall -Wno-error=deprecated-declarations \
+ 	-DG_LOG_DOMAIN="\"LIBDBUSMENU-GTK\""
+
+ libdbusmenu_gtk_la_LIBADD = \
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 64e3e75..699c2c9 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -103,7 +103,7 @@ TESTS_ENVIRONMENT = env GI_TYPELIB_PATH=$(top_builddir)/libdbusmenu-glib:$(top_b
+ ############################################
+
+ DBUSMENU_GLIB_TEST_CFLAGS = \
+-	-Wall -Werror \
++	-Wall \
+ 	-DG_DISABLE_DEPRECATED \
+ 	-I$(top_srcdir) \
+ 	$(DBUSMENUTESTS_CFLAGS) \
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index 029b73e..2258cca 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -16,7 +16,7 @@ dbusmenu_dumper_CFLAGS = \
+ 	-I $(srcdir)/.. \
+ 	$(DBUSMENUGLIB_CFLAGS) \
+ 	$(DBUSMENUDUMPER_CFLAGS) \
+-	-Wall -Werror
++	-Wall
+
+ dbusmenu_dumper_LDADD = \
+ 	../libdbusmenu-glib/libdbusmenu-glib.la \
+

--- a/patches/libunity/0001-Fix-FTB-with-recent-vala-requiring-non-public-abstra.patch
+++ b/patches/libunity/0001-Fix-FTB-with-recent-vala-requiring-non-public-abstra.patch
@@ -1,0 +1,54 @@
+From ef769be7116a5b9cef0f972fb54faed6b75f7dc3 Mon Sep 17 00:00:00 2001
+From: Michael James Gratton <mike@vee.net>
+Date: Mon, 23 Sep 2019 21:07:57 +1000
+Subject: [PATCH] Fix FTB with recent vala requiring non-public abstract class
+ ctors
+
+---
+ src/unity-aggregator-scope.vala | 2 +-
+ src/unity-deprecated-scope.vala | 2 +-
+ tools/preview-renderer.vala     | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/unity-aggregator-scope.vala b/src/unity-aggregator-scope.vala
+index 6664d48..5886e88 100644
+--- a/src/unity-aggregator-scope.vala
++++ b/src/unity-aggregator-scope.vala
+@@ -51,7 +51,7 @@ public abstract class AggregatorScope : DeprecatedScopeBase
+    */
+   public abstract int category_index_for_scope_id (string scope_id);
+ 
+-  public AggregatorScope (string dbus_path_, string id_, MergeMode merge_mode = AggregatorScope.MergeMode.OWNER_SCOPE, bool proxy_filter_hints = false)
++  protected AggregatorScope (string dbus_path_, string id_, MergeMode merge_mode = AggregatorScope.MergeMode.OWNER_SCOPE, bool proxy_filter_hints = false)
+   {
+     Object (dbus_path: dbus_path_, id: id_, is_master: true,
+             merge_mode: merge_mode, proxy_filter_hints: proxy_filter_hints);
+diff --git a/src/unity-deprecated-scope.vala b/src/unity-deprecated-scope.vala
+index 4fc5355..47d8cc8 100644
+--- a/src/unity-deprecated-scope.vala
++++ b/src/unity-deprecated-scope.vala
+@@ -61,7 +61,7 @@ public abstract class DeprecatedScopeBase : GLib.Object
+   internal CategorySet _categories;
+   internal FilterSet _filters;
+    
+-  public DeprecatedScopeBase (string dbus_path_, string id_)
++  protected DeprecatedScopeBase (string dbus_path_, string id_)
+   {
+     Object (dbus_path: dbus_path_, id: id_);
+   }
+diff --git a/tools/preview-renderer.vala b/tools/preview-renderer.vala
+index ed59321..bb0aaf2 100644
+--- a/tools/preview-renderer.vala
++++ b/tools/preview-renderer.vala
+@@ -63,7 +63,7 @@ namespace Unity.Tester {
+      */
+     public abstract class GridRenderer: PreviewRenderer
+     {
+-        public GridRenderer()
++        protected GridRenderer()
+         {
+             Object();
+         }
+-- 
+2.20.1
+

--- a/patches/libunity/libunity-7.1.4-vala-053.patch
+++ b/patches/libunity/libunity-7.1.4-vala-053.patch
@@ -1,0 +1,22 @@
+--- libunity-7.1.4/protocol/protocol-icon.vala.debug	2019-03-19 19:17:56.000000000 +0900
++++ libunity-7.1.4/protocol/protocol-icon.vala	2021-09-13 22:11:06.634930969 +0900
+@@ -185,7 +185,7 @@ public class AnnotatedIcon : Object, GLi
+   }
+ 
+   /* Added to GIcon interface in 2.37 */
+-  private Variant serialize ()
++  private Variant? serialize ()
+   {
+     Variant? ret = null;
+     return ret;
+--- libunity-7.1.4/src/unity-scope-channel.vala.debug	2019-03-19 19:18:05.000000000 +0900
++++ libunity-7.1.4/src/unity-scope-channel.vala	2021-09-13 22:16:25.440323188 +0900
+@@ -312,7 +312,7 @@ internal class ScopeChannel : Object
+           DBusSignalFlags.NONE, this.owner_changed);
+     }
+ 
+-    private void owner_changed (DBusConnection con, string sender_name,
++    private void owner_changed (DBusConnection con, string? sender_name,
+                                 string obj_path, string ifc_name,
+                                 string sig_name, Variant parameters)
+     {


### PR DESCRIPTION
libunity is complete outdated, so it's a nightmare to build. It is [needed by Electron](https://github.com/electron/electron/blob/fb88375ab4d2161dbf7e958a2a94c7c6d97dc84c/shell/browser/linux/unity_service.cc#L74) for [setProgressBar](https://www.electronjs.org/de/docs/latest/api/browser-window#winsetprogressbarprogress-options) and [setBadgeCount](https://www.electronjs.org/de/docs/latest/api/browser-window#winsetprogressbarprogress-options). You can use this [example code](https://www.electronjs.org/de/docs/latest/tutorial/progress-bar) to test it out.

The app need the `--socket=session-bus` permission for some reason. You actually just [need to emit a DBus signal](https://gist.github.com/lephuongbg/1830d1e03ac45faa11e1bbd7204eee5d), which should work without any permission.

A big problem is, that this API uses the desktop file name. You need to set `desktopName` field in the `package.json` to the correct name, otherwise it uses the name if the App, which is not the Flatpak ID. So this will cause problems when repacking existing binaries. I ping @refi64. Maybe he has a Idea what to do about that.

Packagers should also set the `StartupWMClass` field in the desktop entry, otherwise the desktop file can't be connected to the App.

Another problem is, that [Electron checks for some reason the current desktop](https://github.com/electron/electron/blob/fb88375ab4d2161dbf7e958a2a94c7c6d97dc84c/shell/browser/linux/unity_service.cc#L64). This is supported by more Desktops e.g. Mate as the ones Electron checks, so packages should overwrite the `XDG_CURRENT_DESKTOP` environment variable to make it work on every desktop.

This PR is heavily based on [this PR here](https://github.com/flathub/com.discordapp.Discord/pull/167) and the AUR packages of the used software.

For reference:
flathub/com.discordapp.Discord#228
Heroic-Games-Launcher/HeroicGamesLauncher#3478