### PR TITLE
Add patch-desktop-filename script

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -61,6 +61,26 @@ modules:
         commands: [autoreconf -vfi]
         dest-filename: autogen.sh
 
+  - name: python3-asarPy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "asarPy" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/d7/ab/6c971fb30ffd7f892eada14f28b439f5621fb291bd333e3d67af1e208e49/asarPy-1.0.1.tar.gz
+        sha256: 1f1a9a230942da620bc134eccda7be352f731301ac1269e71e426419e433a0d6
+        x-checker-data:
+          name: asarPy
+
+  - name: patch-desktop-filename
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 patch-desktop-filename.py ${FLATPAK_DEST}/bin/patch-desktop-filename
+    sources:
+      - type: file
+        path: patch-desktop-filename.py
+
   - name: zypak
     sources:
       - type: git

--- a/patch-desktop-filename.py
+++ b/patch-desktop-filename.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import tempfile
+import asarPy
+import shutil
+import json
+import sys
+import os
+
+
+def main() -> None:
+    asar_path = sys.argv[1]
+    extract_dir = tempfile.mktemp()
+
+    asarPy.extract_asar(asar_path, extract_dir)
+
+    with open(os.path.join(extract_dir, "package.json"), "r", encoding="utf-8") as f:
+        package_json = json.load(f)
+
+    package_json["desktopName"] = os.getenv("FLATPAK_ID") + ".desktop"
+
+    with open(os.path.join(extract_dir, "package.json"), "w", encoding="utf-8") as f:
+        json.dump(package_json, f)
+
+    asarPy.pack_asar(extract_dir, asar_path)
+
+    shutil.rmtree(extract_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/patch-desktop-filename.py
+++ b/patch-desktop-filename.py
@@ -1,4 +1,30 @@
 #!/usr/bin/env python
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2024, JakobDev
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import tempfile
 import asarPy
 import shutil


### PR DESCRIPTION
This PR belongs to #55 

As mentioned in the other PR, showing a number and a progress bar in the window icon needs the correct desktop filename in the package.json, which is a problem for most Flatpaks. This PR solves the problem by providing a script to do that. You just need to call the script with the `app.asar` as parameter and it will do the Rest. I have modified the Element Flatpak as a Demo.

<details>
  <summary>Manifest</summary>
  
```yaml
app-id: im.riot.Riot
base: org.electronjs.Electron2.BaseApp
base-version: '23.08'
runtime: org.freedesktop.Platform
runtime-version: '23.08'
sdk: org.freedesktop.Sdk
command: element
separate-locales: false
finish-args:
  # Version required to use the document-portal v4
  - --require-version=1.7.0
  # Required due to being a GUI application
  - --socket=x11
  # Required to make sure x11 performance is achived on all platforms
  # At least that's what the legends tell. it might be worth experimenting
  # with dropping this permission.
  - --share=ipc
  # Required for experimental wayland support
  - --socket=wayland
  # Required to provide Call functionality
  - --socket=pulseaudio
  - --device=all
  # As a chat application, networking is required
  - --share=network
  # Required for notifications in various desktop environments
  - --talk-name=org.kde.StatusNotifierWatcher
  # Required to allow screensaver/idle inhibition such as during video calls
  - --talk-name=org.freedesktop.ScreenSaver
  # Required to store access tokens (persistent logins)
  - --filesystem=xdg-run/keyring
  # Required for experimental wayland support
  - --filesystem=xdg-run/pipewire-0
  # For correct cursor scaling under Wayland
  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
  - --talk-name=com.canonical.Unity
  - --env=XDG_CURRENT_SESSION=KDE

cleanup:
  - /include
  - /lib/pkgconfig
  - /lib/*.la
  - /lib/*.a
  - /share/pkgconfig
  - /share/aclocal
  - /share/gtk-doc
  - /share/doc
  - /share/info
  - /share/man
  - /man
modules:
  - name: riot
    buildsystem: simple
    build-commands:
      - install element.sh /app/bin/element
      - install -Dm644 im.riot.Riot.desktop /app/share/applications/im.riot.Riot.desktop
      - install -Dm644 im.riot.Riot.metainfo.xml /app/share/metainfo/im.riot.Riot.metainfo.xml
      - rm element.sh im.riot.Riot.desktop im.riot.Riot.metainfo.xml
      - install -Dm644 resources/img/element.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
      - mkdir /app/Element
      - cp -r * /app/Element
      - chmod -R a-s,go+rX,go-w "/app/Element"
      - patch-desktop-filename ${FLATPAK_DEST}/Element/resources/app.asar
    sources:
      - type: archive
        only-arches:
          - x86_64
        url: https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-1.11.57.tar.gz
        sha256: da2654b17b5dbe58e8e939dc98bc29873df19b4799421c681c468c0e132f54db
        x-checker-data:
          type: html
          url: https://packages.element.io/desktop/install/linux/glibc-x86-64/index.html
          version-pattern: element-desktop-([\d\.-]*).tar.gz
          url-template: https://packages.element.io/desktop/install/linux/glibc-x86-64/element-desktop-$version.tar.gz
      - type: file
        path: element.sh
      - type: file
        path: im.riot.Riot.metainfo.xml
      - type: file
        path: im.riot.Riot.desktop
  ```
  
</details>

Result:
![grafik](https://github.com/flathub/org.electronjs.Electron2.BaseApp/assets/15185051/557855de-1002-4a13-a8ab-a8f4431a4d05)

