### PR TITLE
Include libspeechd for SpeechSynthesis support

### DIFF
--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -134,6 +134,4 @@ modules:
               - autoreconf -fiv
             dest-filename: autogen.sh
         cleanup:
-          - /include
-          - /lib/pkgconfig
-          - /share/doc
+          - "*"

--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -109,7 +109,6 @@ modules:
       - --with-voxin=no
       - --without-flite
       - --disable-python
-      - --with-systemdsystemunitdir=/app/lib/systemd/system/speech-dispatcherd.service
     no-make-install: true
     post-install:
       - cd ./src/api/c && make install

--- a/org.electronjs.Electron2.BaseApp.yml
+++ b/org.electronjs.Electron2.BaseApp.yml
@@ -94,3 +94,46 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
+
+  # Chromium dynamically loads the Speech Dispatcher library libspeechd.so.2.
+  # If present, and --enable-speech-dispatcher flag is passed, Web Speech API will be enabled.
+  # This section is borrowed and tweaked from:
+  # https://github.com/flathub/net.lutris.Lutris/blob/76e94a0b80ef3ebc1b9a6b61f47d736f5ddd772c/net.lutris.Lutris.yml#L495
+  # https://gitlab.archlinux.org/archlinux/packaging/packages/speech-dispatcher/-/blob/414baaf78b5fe416df88a89ac18d2dd579a0c653/PKGBUILD
+  - name: libspeechd
+    config-opts:
+      - --disable-static
+      - --with-ibmtts=no
+      - --with-kali=no
+      - --with-baratinoo=no
+      - --with-voxin=no
+      - --without-flite
+      - --disable-python
+      - --with-systemdsystemunitdir=/app/lib/systemd/system/speech-dispatcherd.service
+    no-make-install: true
+    post-install:
+      - cd ./src/api/c && make install
+    cleanup:
+      - "*.la"
+      - "*.a"
+      - /include
+    sources:
+      - type: archive
+        url: https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz
+        sha512: d6d880bce0ae5bc2a5d519ef7740c689ae8b4b0bb658379762810e4beae3e465a429fbe19f7c490e89db0ea6a36aedd4b2287ac9251b90059b5c2cb3c0dd8a28
+    modules:
+      # dotconf provides utility functions to parse config files. It's only linked with the speech-dispatcher server,
+      # which we aren't building, but it needs to exist to get past the ./configure step anyway
+      - name: dotconf
+        sources:
+          - type: archive
+            url: https://github.com/williamh/dotconf/archive/refs/tags/v1.4.1.tar.gz
+            sha512: a6cada8621295b268d4b4fd85bc0c207e78324c9e84754ead2fdf6c1598ec8bdf626f9c24e66063d921c95d73e83b50ab50416a9b4c9a7a631392552ec46f55a
+          - type: script
+            commands:
+              - autoreconf -fiv
+            dest-filename: autogen.sh
+        cleanup:
+          - /include
+          - /lib/pkgconfig
+          - /share/doc


### PR DESCRIPTION
Electron apps may want to use the SpeechSynthesis part of the Web Speech API.

On Linux, this is gated behind the `--enable-speech-dispatcher` flag. If enabled, Chromium will attempt to dynamically load the Speech Dispatcher library `libspeechd.so.2`. If not present, speech is disabled. [Chromium source code for proof](https://source.chromium.org/chromium/chromium/src/+/refs/tags/122.0.6261.111:content/browser/speech/tts_linux.cc;l=251). Right now this library isn't included inside the Flatpak, even though the host may be fully configured with Speech Dispatcher.

This PR builds and includes the library (but not the daemon) so that TTS stuff can easily work as long as the consuming app passes the `--enable-speech-dispatcher` flag and has sandbox perms for `--filesystem=xdg-run/speech-dispatcher`.

This is useful for flathub/dev.vencord.Vesktop#20, though we thought it'd make sense to upstream it for other apps' benefit.