### PR TITLE
Update patch-electron-desktop-filename to 1.1

### DIFF
--- a/patch-electron-desktop-filename/go.mod.yml
+++ b/patch-electron-desktop-filename/go.mod.yml
@@ -3,10 +3,10 @@
   path: modules.txt
   type: file
 - dest: vendor/codeberg.org/jakobdev/asar-go
-  sha256: 493a22c2fc861e75faea5803856a5048ae80e9625d754db9d8eb043faf819e98
+  sha256: 5acbe7e0dfada64a01e1668cdfa3437fbeae5291d5fd4ae0626fe7e0595dd440
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/codeberg.org/jakobdev/asar-go/@v/v1.1.0.zip
+  url: https://proxy.golang.org/codeberg.org/jakobdev/asar-go/@v/v1.1.1.zip
 - dest: vendor/github.com/alecthomas/kong
   sha256: f7f01c58ed360875af0ae0c0f366ee68d20143ae2d7d82d96fbe091f1d9316da
   strip-components: 3

--- a/patch-electron-desktop-filename/modules.txt
+++ b/patch-electron-desktop-filename/modules.txt
@@ -1,4 +1,4 @@
-# codeberg.org/jakobdev/asar-go v1.1.0
+# codeberg.org/jakobdev/asar-go v1.1.1
 ## explicit; go 1.26
 codeberg.org/jakobdev/asar-go
 # github.com/alecthomas/kong v1.14.0

--- a/patch-electron-desktop-filename/patch-electron-desktop-filename.yml
+++ b/patch-electron-desktop-filename/patch-electron-desktop-filename.yml
@@ -7,8 +7,8 @@ build-commands:
   - install -Dm755 patch-electron-desktop-filename -t ${FLATPAK_DEST}/bin
 sources:
   - type: archive
-    url: https://codeberg.org/JakobDev/patch-electron-desktop-filename/archive/1.0.tar.gz
-    sha256: 368afae6b31168def79d1716fbcb3d885125755e05171ebb29224668229046e8
+    url: https://codeberg.org/JakobDev/patch-electron-desktop-filename/archive/1.1.tar.gz
+    sha256: 7d3d2907d8bdf8c261fd04bd9042765bc4194442a9d09061f16452c890d7071f
     x-checker-data:
       type: json
       url: https://codeberg.org/api/v1/repos/JakobDev/patch-electron-desktop-filename/releases/latest


### PR DESCRIPTION
This update just include [a small ifx](https://codeberg.org/JakobDev/asar-go/commit/5b46cfc4f5c9ad14ee0ce823386564014718a0da) for a bug that causes an invalid header sometimes. A test has been added to make sure it doesn't happen again.

This bug doesn't occur in my tests the previous days, so sorry for that.