### PR TITLE
Update patch-electron-desktop-filename to 1.3

### DIFF
--- a/patch-electron-desktop-filename/go.mod.yml
+++ b/patch-electron-desktop-filename/go.mod.yml
@@ -3,15 +3,15 @@
   path: modules.txt
   type: file
 - dest: vendor/codeberg.org/jakobdev/asar-go
-  sha256: 5acbe7e0dfada64a01e1668cdfa3437fbeae5291d5fd4ae0626fe7e0595dd440
+  sha256: 1eee86b5548679833ec5407ee1d27cffffe4594d6be21aec54fe562018ef3e2a
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/codeberg.org/jakobdev/asar-go/@v/v1.1.1.zip
+  url: https://proxy.golang.org/codeberg.org/jakobdev/asar-go/@v/v1.2.0.zip
 - dest: vendor/github.com/alecthomas/kong
-  sha256: f7f01c58ed360875af0ae0c0f366ee68d20143ae2d7d82d96fbe091f1d9316da
+  sha256: 40af0f7342da8b195cfa4b95abec2120201fca16c1563e08dbf60efb8583f9e0
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/github.com/alecthomas/kong/@v/v1.14.0.zip
+  url: https://proxy.golang.org/github.com/alecthomas/kong/@v/v1.15.0.zip
 - dest: vendor/golang.org/x/sync
   sha256: 7179d4d68800f6fdcadb9d4bbf11cbb5df9b40360c89305c203fe20723cbd375
   strip-components: 3

--- a/patch-electron-desktop-filename/modules.txt
+++ b/patch-electron-desktop-filename/modules.txt
@@ -1,7 +1,7 @@
-# codeberg.org/jakobdev/asar-go v1.1.1
+# codeberg.org/jakobdev/asar-go v1.2.0
 ## explicit; go 1.26
 codeberg.org/jakobdev/asar-go
-# github.com/alecthomas/kong v1.14.0
+# github.com/alecthomas/kong v1.15.0
 ## explicit; go 1.20
 github.com/alecthomas/kong
 # golang.org/x/sync v0.20.0

--- a/patch-electron-desktop-filename/patch-electron-desktop-filename.yml
+++ b/patch-electron-desktop-filename/patch-electron-desktop-filename.yml
@@ -7,8 +7,8 @@ build-commands:
   - install -Dm755 patch-electron-desktop-filename -t ${FLATPAK_DEST}/bin
 sources:
   - type: archive
-    url: https://codeberg.org/JakobDev/patch-electron-desktop-filename/archive/1.2.tar.gz
-    sha256: a9932f360343272413a73d70c0571167a71192f0b1be15d8b52f65d278c66051
+    url: https://codeberg.org/JakobDev/patch-electron-desktop-filename/archive/1.3.tar.gz
+    sha256: 9428cd446071139ebe1b1132ae8803f28dd46efdc50ea2dd5621e8f6f4962052
     x-checker-data:
       type: json
       url: https://codeberg.org/api/v1/repos/JakobDev/patch-electron-desktop-filename/releases/latest


### PR DESCRIPTION
This version limits the number of active threads to the number of logical CPUs, which fixes problems with a huge RAM consumption.